### PR TITLE
Added simple color-picker

### DIFF
--- a/components/ColorPicker.js
+++ b/components/ColorPicker.js
@@ -1,26 +1,62 @@
 import React, { useState } from "react";
 import { HexColorPicker } from "react-colorful";
 
+const savedColorsDefault = [
+  {
+    id: 0,
+    hex: "#eeeeee",
+  },
+  {
+    id: 1,
+    hex: "#eeeeee",
+  },
+  {
+    id: 2,
+    hex: "#eeeeee",
+  },
+  {
+    id: 3,
+    hex: "#eeeeee",
+  },
+  {
+    id: 4,
+    hex: "#eeeeee",
+  },
+  {
+    id: 5,
+    hex: "#eeeeee",
+  },
+  {
+    id: 6,
+    hex: "#eeeeee",
+  },
+  {
+    id: 7,
+    hex: "#eeeeee",
+  },
+  {
+    id: 8,
+    hex: "#eeeeee",
+  },
+  {
+    id: 9,
+    hex: "#eeeeee",
+  },
+];
+
 const ColorPicker = () => {
   const [color, setColor] = useState("#000000");
+  const [savedColors, setSavedColors] = useState(savedColorsDefault);
 
-  const temperatureBands = [
-    {
-      low: 11,
-      high: 20,
-      color: "#b49be6",
-    },
-    {
-      low: 21,
-      high: 30,
-      color: "#c16060",
-    },
-    {
-      low: 31,
-      high: 40,
-      color: "#49c13c",
-    },
-  ];
+  const handleSave = (idToUpdate, hexToUpdate) => {
+    setSavedColors(
+      savedColors.map((previousColor) =>
+        previousColor.id === idToUpdate
+          ? { ...previousColor, hex: hexToUpdate }
+          : previousColor
+      )
+    );
+  };
 
   return (
     <div className="mt-10 flex">
@@ -29,18 +65,27 @@ const ColorPicker = () => {
         <p style={{ backgroundColor: `${color}` }}>{color}</p>
       </div>
       <div>
-        {temperatureBands.map((band, index) => (
-          <div className="flex" key={index}>
-            <p className="px-2">{band.low}</p>
-            <p className="px-2">{band.high}</p>
-            <p
-              style={{ backgroundColor: band.color }}
-              className="m-1 px-2 w-40"
-            >
-              {band.color}
-            </p>
-          </div>
-        ))}
+        <h3>Saved Colors</h3>
+        <div>
+          {savedColors.map((item) => (
+            <div>
+              <p
+                style={{ backgroundColor: `${item.hex}` }}
+                key={item.id}
+                className="m-2 w-30"
+                onClick={() => handleSave(item.id, color)}
+              >
+                {item.id}: {item.hex}
+              </p>
+              {/* <button
+                className="border"
+                onClick={() => handleSave(item.id, color)}
+              >
+                save here
+              </button> */}
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/components/ColorPicker.js
+++ b/components/ColorPicker.js
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import { HexColorPicker } from "react-colorful";
+
+const ColorPicker = () => {
+  const [color, setColor] = useState("#000000");
+
+  const temperatureBands = [
+    {
+      low: 11,
+      high: 20,
+      color: "#b49be6",
+    },
+    {
+      low: 21,
+      high: 30,
+      color: "#c16060",
+    },
+    {
+      low: 31,
+      high: 40,
+      color: "#49c13c",
+    },
+  ];
+
+  return (
+    <div className="mt-10 flex">
+      <HexColorPicker color={color} onChange={setColor} />
+      <div className="p-10 w-40">
+        <p style={{ backgroundColor: `${color}` }}>{color}</p>
+      </div>
+      <div>
+        {temperatureBands.map((band, index) => (
+          <div className="flex" key={index}>
+            <p className="px-2">{band.low}</p>
+            <p className="px-2">{band.high}</p>
+            <p
+              style={{ backgroundColor: band.color }}
+              className="m-1 px-2 w-40"
+            >
+              {band.color}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ColorPicker;

--- a/components/ColorPicker.js
+++ b/components/ColorPicker.js
@@ -90,22 +90,19 @@ const ColorPicker = () => {
         <div className="flex mt-5">
           <div className="container m-auto grid">
             {tempRange.map((item) => (
-              <div>
-                <p key={item.id} className="w-30 m-1">
-                  {item.value}
-                </p>
+              <div key={item.id}>
+                <p className="w-30 m-1">{item.value}</p>
               </div>
             ))}
           </div>
           <div className="container m-auto grid">
             {savedColors.map((item) => (
-              <div>
+              <div key={item.id}>
                 <p
                   style={{
                     backgroundColor: `${item.hex}`,
                     color: `${item.hex}`,
                   }}
-                  key={item.id}
                   className="w-30 m-1"
                   onClick={() => handleSave(item.id, color)}
                 >

--- a/components/ColorPicker.js
+++ b/components/ColorPicker.js
@@ -44,9 +44,23 @@ const savedColorsDefault = [
   },
 ];
 
+const tempRangeDefault = [
+  { id: "temp01", value: "0 - 9" },
+  { id: "temp02", value: "10 - 19" },
+  { id: "temp02", value: "20 - 29" },
+  { id: "temp02", value: "30 - 39" },
+  { id: "temp02", value: "40 - 49" },
+  { id: "temp02", value: "50 - 59" },
+  { id: "temp02", value: "60 - 69" },
+  { id: "temp02", value: "70 - 79" },
+  { id: "temp02", value: "80 - 89" },
+  { id: "temp02", value: "90 - 99" },
+];
+
 const ColorPicker = () => {
   const [color, setColor] = useState("#000000");
   const [savedColors, setSavedColors] = useState(savedColorsDefault);
+  const [tempRange, setTempRange] = useState(tempRangeDefault);
 
   const handleSave = (idToUpdate, hexToUpdate) => {
     setSavedColors(
@@ -59,32 +73,47 @@ const ColorPicker = () => {
   };
 
   return (
-    <div className="mt-10 flex">
+    <div className="mt-10 md:flex">
       <HexColorPicker color={color} onChange={setColor} />
       <div className="p-10 w-40">
-        <p style={{ backgroundColor: `${color}` }}>{color}</p>
+        <h3>Current Color</h3>
+        <p style={{ backgroundColor: `${color}`, color: `${color}` }}>
+          {color}
+        </p>
       </div>
       <div>
         <h3>Saved Colors</h3>
-        <div>
-          {savedColors.map((item) => (
-            <div>
-              <p
-                style={{ backgroundColor: `${item.hex}` }}
-                key={item.id}
-                className="m-2 w-30"
-                onClick={() => handleSave(item.id, color)}
-              >
-                {item.id}: {item.hex}
-              </p>
-              {/* <button
-                className="border"
-                onClick={() => handleSave(item.id, color)}
-              >
-                save here
-              </button> */}
-            </div>
-          ))}
+        <div className="flex">
+          <p className="text-xs w-20">temperature range</p>
+          <p className="text-xs w-20">click in box to save current color</p>
+        </div>
+        <div className="flex mt-5">
+          <div className="container m-auto grid">
+            {tempRange.map((item) => (
+              <div>
+                <p key={item.id} className="w-30 m-1">
+                  {item.value}
+                </p>
+              </div>
+            ))}
+          </div>
+          <div className="container m-auto grid">
+            {savedColors.map((item) => (
+              <div>
+                <p
+                  style={{
+                    backgroundColor: `${item.hex}`,
+                    color: `${item.hex}`,
+                  }}
+                  key={item.id}
+                  className="w-30 m-1"
+                  onClick={() => handleSave(item.id, color)}
+                >
+                  {item.hex}
+                </p>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "next": "13.2.4",
         "rc-table": "^7.31.1",
         "react": "18.2.0",
+        "react-colorful": "^5.6.1",
         "react-dom": "18.2.0",
         "react-icons": "^4.8.0"
       },
@@ -3249,6 +3250,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -6112,6 +6122,12 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "requires": {}
     },
     "react-dom": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "next": "13.2.4",
     "rc-table": "^7.31.1",
     "react": "18.2.0",
+    "react-colorful": "^5.6.1",
     "react-dom": "18.2.0",
     "react-icons": "^4.8.0"
   },

--- a/pages/palette.js
+++ b/pages/palette.js
@@ -1,23 +1,26 @@
-import { FaHardHat } from 'react-icons/fa'
-import { Shadows_Into_Light } from 'next/font/google'
+import { FaHardHat } from "react-icons/fa";
+import { Shadows_Into_Light } from "next/font/google";
+import ColorPicker from "@/components/ColorPicker";
 
-const shadows = Shadows_Into_Light({ 
-  subsets: ['latin'],
-  weight: ['400'],
-})
+const shadows = Shadows_Into_Light({
+  subsets: ["latin"],
+  weight: ["400"],
+});
 
 const Palette = () => {
   return (
-    <div className='bg-slate-400 flex flex-col items-center pt-20 min-h-screen'>
+    <div className="bg-slate-100 flex flex-col items-center pt-20 min-h-screen">
       <div className={shadows.className}>
-        <h2 className='text-2xl font-bold text-sky-600'>Palette Planner</h2>
+        <h2 className="text-2xl font-bold text-sky-600">Palette Planner</h2>
       </div>
-      <p className='text-rose-700'>This feature is under contruction.</p>
-      <p><FaHardHat /></p>
+      <p className="text-rose-700">This feature is under contruction.</p>
+      <p>
+        <FaHardHat />
+      </p>
       <p>Thank you for your patience.</p>
-
+      <ColorPicker />
     </div>
-  )
-}
+  );
+};
 
-export default Palette
+export default Palette;

--- a/pages/palette.js
+++ b/pages/palette.js
@@ -9,7 +9,7 @@ const shadows = Shadows_Into_Light({
 
 const Palette = () => {
   return (
-    <div className="bg-slate-100 flex flex-col items-center pt-20 min-h-screen">
+    <div className="bg-slate-100 flex flex-col pt-20 px-5 min-h-screen">
       <div className={shadows.className}>
         <h2 className="text-2xl font-bold text-sky-600">Palette Planner</h2>
       </div>
@@ -17,7 +17,15 @@ const Palette = () => {
       <p>
         <FaHardHat />
       </p>
-      <p>Thank you for your patience.</p>
+      <p>
+        You can pick colors from the color selector on the left by dragging one
+        of the circles to any color you like and then save that color to a
+        specific temperature range by clicking on a box to the right.
+      </p>
+      <p>
+        In the future, you will be able to imput temperature ranges of you
+        choice.
+      </p>
       <ColorPicker />
     </div>
   );


### PR DESCRIPTION
- set up react-colorful as color-picker (more recently updated and more lightweight, better choice for simple application)
- current color choice saved in state
- saved color container pre-filled with 10 fixed temperature ranges and 10 color placeholder boxes
- clicking a placeholder box sets the current color to clicked box
- all colors saved in state only

Next steps:

- save colors to local storage
- make temperature ranges editable by user